### PR TITLE
fix: empty tag needs to be empty string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rocicorp/logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rocicorp/logger",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rocicorp/logger",
   "description": "Logging utilities",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": "github:rocicorp/logger",
   "license": "Apache-2.0",
   "engines": {

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -97,3 +97,18 @@ test('LogContext default level', () => {
   expect(mockInfo.lastCall.args).to.deep.equal(['bbb']);
   expect(mockError.lastCall.args).to.deep.equal(['ccc']);
 });
+
+test('Optional tag', () => {
+  const mockDebug = mockConsoleMethod('debug');
+  const lc = new LogContext('debug');
+  lc.debug?.('a');
+  expect(mockDebug.lastCall.args).to.deep.equal(['a']);
+
+  const lc2 = lc.addContext('b');
+  lc2.debug?.('c');
+  expect(mockDebug.lastCall.args).to.deep.equal(['b', 'c']);
+
+  const lc3 = lc.addContext('d', 'e');
+  lc3.debug?.('f');
+  expect(mockDebug.lastCall.args).to.deep.equal(['d=e', 'f']);
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -90,13 +90,13 @@ export class SilentLogger implements OptionalLogger {
  *   f(lc2);  // logging inside f will be prefixed with 'foo'
  */
 export class LogContext extends OptionalLoggerImpl {
-  private readonly _s;
+  private readonly _s: string;
   private readonly _logger: OptionalLogger;
 
   /**
    * @param loggerOrLevel If passed a LogLevel a ConsoleLogget is used
    */
-  constructor(loggerOrLevel: OptionalLogger | LogLevel = 'info', tag?: string) {
+  constructor(loggerOrLevel: OptionalLogger | LogLevel = 'info', tag = '') {
     const actualLogger: OptionalLogger = isLogLevel(loggerOrLevel)
       ? new OptionalLoggerImpl(consoleLogger, loggerOrLevel)
       : loggerOrLevel;


### PR DESCRIPTION
Using `undefined` as the default value for optional `tag` parameter lead
to `"undefined"` being printed.