### PR TITLE
feat: Stringify objects for console log sink

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.13.x, 16.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "4.0.0",
   "repository": "github:rocicorp/logger",
   "license": "Apache-2.0",
+  "engines": {
+    "node": "^14.13.1 || >=16.0.0"
+  },
   "scripts": {
     "test": "mocha --ui=tdd out/*.test.js",
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "version": "4.0.0",
   "repository": "github:rocicorp/logger",
   "license": "Apache-2.0",
-  "engines": {
-    "node": "^14.13.1 || >=16.0.0"
-  },
   "scripts": {
     "test": "mocha --ui=tdd out/*.test.js",
     "pretest": "npm run build",

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -248,3 +248,15 @@ test('Console logger calls JSON stringify on complex arguments', () => {
   assert.deepEqual(jsonStringifySpy.getCall(0).args, [{b: 1}]);
   assert.deepEqual(jsonStringifySpy.getCall(1).args, [[2, 3]]);
 });
+
+test('newNodeLogContext calls JSON stringify on complex arguments', () => {
+  const jsonStringifySpy = sinon.spy(JSON, 'stringify');
+  const mockDebug = mockConsoleMethod('debug');
+  const lc = newNodeLogContext('debug');
+  lc.debug?.('a', false, 123, {b: 1}, [2, 3]);
+  assert(mockDebug.calledOnce);
+  assert(mockDebug.calledWith('DBG', 'a', false, 123, '{"b":1}', '[2,3]'));
+  assert.equal(jsonStringifySpy.callCount, 2);
+  assert.deepEqual(jsonStringifySpy.getCall(0).args, [{b: 1}]);
+  assert.deepEqual(jsonStringifySpy.getCall(1).args, [[2, 3]]);
+});

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,6 +1,7 @@
-import {expect} from 'chai';
+import {expect, assert} from 'chai';
 import {
   ConsoleLogger,
+  consoleLogSink,
   FormatLogger,
   LogContext,
   LogSink,
@@ -235,4 +236,15 @@ test('tee logger flush', async () => {
   await tl.flush();
   expect(l1.flushCount).to.equal(1);
   expect(l3.flushCount).to.equal(1);
+});
+
+test('Console logger calls JSON stringify on complex arguments', () => {
+  const jsonStringifySpy = sinon.spy(JSON, 'stringify');
+  const mockDebug = mockConsoleMethod('debug');
+  consoleLogSink.log('debug', 'a', false, 123, {b: 1}, [2, 3]);
+  assert(mockDebug.calledOnce);
+  assert(mockDebug.calledWith('a', false, 123, '{"b":1}', '[2,3]'));
+  assert.equal(jsonStringifySpy.callCount, 2);
+  assert.deepEqual(jsonStringifySpy.getCall(0).args, [{b: 1}]);
+  assert.deepEqual(jsonStringifySpy.getCall(1).args, [[2, 3]]);
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -84,7 +84,7 @@ export class ConsoleLogger extends OptionalLoggerImpl {
  */
 export const consoleLogSink: LogSink = {
   log(level: LogLevel, ...args: unknown[]): void {
-    console[level](...args);
+    console[level](...args.map(normalizeArgument));
   },
 };
 
@@ -161,4 +161,24 @@ export class LogContext extends OptionalLoggerImpl {
     };
     return new LogContext(this._level, logSink);
   }
+}
+
+function normalizeArgument(
+  v: unknown,
+): string | number | boolean | null | undefined | symbol | bigint {
+  switch (typeof v) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+    case 'undefined':
+    case 'symbol':
+    case 'bigint':
+      return v;
+    case 'object':
+      if (v === null) {
+        return null;
+      }
+      break;
+  }
+  return JSON.stringify(v);
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -108,7 +108,7 @@ export class FormatLogger implements LogSink {
  */
 export const nodeConsoleLogSink: LogSink = {
   log(level: LogLevel, ...args: unknown[]): void {
-    console[level](logLevelPrefix[level], ...args);
+    console[level](logLevelPrefix[level], ...args.map(normalizeArgument));
   },
 };
 
@@ -180,5 +180,17 @@ function normalizeArgument(
       }
       break;
   }
-  return JSON.stringify(v);
+  return JSON.stringify(v, errorReplacer);
+}
+
+function errorReplacer(_key: string | symbol, v: unknown) {
+  if (v instanceof Error) {
+    return {
+      name: v.name,
+      message: v.message,
+      stack: v.stack,
+      ...('cause' in v ? {cause: v.cause} : null),
+    };
+  }
+  return v;
 }


### PR DESCRIPTION
The consoleLogSink often used with environments that do not print object, such as NodeJS and CF Workers. We therefore stringify all objects using JSON.stringify.

Closes https://github.com/rocicorp/mono/issues/168