### PR TITLE
Change the LogSink interface to take an optional Context object

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ import {LogContext} from '@rocicorp/logger';
 const lc = new LogContext('info');
 lc.info('hello'); // prints "hello"
 
-const lc2 = new LogContext('info', 'name');
-lc.info('hello'); // prints "name hello"
+const lc2 = new LogContext('info', {name: 'alice'});
+lc.info('hello'); // prints "name=alice hello"
 
 const lc3 = lc2.withContext('bbb');
-lc3.info('hello'); // prints "name bbb hello"
+lc3.info('hello'); // prints "name=alice bbb hello"
 
 const lc4 = lc3.withContext('ccc');
-lc4.info('hello'); // prints "name bbb ccc hello"
+lc4.info('hello'); // prints "name=alice bbb ccc hello"
 
 const lc5 = lc4.withContext('ddd', 'eee');
-lc5.info('hello'); // prints "name bbb ccc ddd=eee hello"
+lc5.info('hello'); // prints "name=alice bbb ccc ddd=eee hello"
 
 // Or get a context logger appropriate for the Node environment.
 const nlc = newNodeLogContext('debug');

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ lc.info('hello'); // prints "hello"
 const lc2 = new LogContext('info', 'name');
 lc.info('hello'); // prints "name hello"
 
-const lc3 = lc2.addContext('bbb');
+const lc3 = lc2.withContext('bbb');
 lc3.info('hello'); // prints "name bbb hello"
 
-const lc4 = lc3.addContext('ccc');
+const lc4 = lc3.withContext('ccc');
 lc4.info('hello'); // prints "name bbb ccc hello"
 
-const lc5 = lc4.addContext('ddd', 'eee');
+const lc5 = lc4.withContext('ddd', 'eee');
 lc5.info('hello'); // prints "name bbb ccc ddd=eee hello"
 
 // Or get a context logger appropriate for the Node environment.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rocicorp/logger",
   "description": "Logging utilities",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "repository": "github:rocicorp/logger",
   "license": "Apache-2.0",
   "engines": {

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -175,12 +175,10 @@ test('Optional tag', () => {
 });
 
 class TestLogSink implements LogSink {
-  // Note: Order in messages is different from log args order to verify
-  // that Context isn't just one of the args.
-  messages: [Context | undefined, LogLevel, ...unknown[]][] = [];
+  messages: [LogLevel, Context | undefined, unknown[]][] = [];
 
   log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
-    this.messages.push([context, level, ...args]);
+    this.messages.push([level, context, args]);
   }
 }
 
@@ -203,29 +201,29 @@ test('TeeLogSink', () => {
   expect(l2.messages).to.deep.equal([]);
 
   tl.log('info', ctx, 1, 2);
-  expect(l1.messages).to.deep.equal([[ctx, 'info', 1, 2]]);
-  expect(l2.messages).to.deep.equal([[ctx, 'info', 1, 2]]);
+  expect(l1.messages).to.deep.equal([['info', ctx, [1, 2]]]);
+  expect(l2.messages).to.deep.equal([['info', ctx, [1, 2]]]);
 
   tl.log('debug', ctx, 3);
   expect(l1.messages).to.deep.equal([
-    [ctx, 'info', 1, 2],
-    [ctx, 'debug', 3],
+    ['info', ctx, [1, 2]],
+    ['debug', ctx, [3]],
   ]);
   expect(l2.messages).to.deep.equal([
-    [ctx, 'info', 1, 2],
-    [ctx, 'debug', 3],
+    ['info', ctx, [1, 2]],
+    ['debug', ctx, [3]],
   ]);
 
   tl.log('error', ctx, 4, 5, 6);
   expect(l1.messages).to.deep.equal([
-    [ctx, 'info', 1, 2],
-    [ctx, 'debug', 3],
-    [ctx, 'error', 4, 5, 6],
+    ['info', ctx, [1, 2]],
+    ['debug', ctx, [3]],
+    ['error', ctx, [4, 5, 6]],
   ]);
   expect(l2.messages).to.deep.equal([
-    [ctx, 'info', 1, 2],
-    [ctx, 'debug', 3],
-    [ctx, 'error', 4, 5, 6],
+    ['info', ctx, [1, 2]],
+    ['debug', ctx, [3]],
+    ['error', ctx, [4, 5, 6]],
   ]);
 });
 
@@ -243,11 +241,11 @@ test('Context-aware LogSink', () => {
   lc.debug?.(7, 8);
 
   expect(sink.messages).to.deep.equal([
-    [undefined, 'info', 1, 2],
-    [{foo: {bar: 'baz'}}, 'debug', 3, 4],
-    [{boo: 'oof'}, 'info', 5, 6],
-    [{abc: 'is', easy: 'as'}, 'info', 1, 2, 3],
-    [undefined, 'debug', 7, 8],
+    ['info', undefined, [1, 2]],
+    ['debug', {foo: {bar: 'baz'}}, [3, 4]],
+    ['info', {boo: 'oof'}, [5, 6]],
+    ['info', {abc: 'is', easy: 'as'}, [1, 2, 3]],
+    ['debug', undefined, [7, 8]],
   ]);
 });
 

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -131,15 +131,15 @@ test('LogContext formatting', () => {
   lc.debug?.('aaa');
   expect(mockDebug.lastCall.args).to.deep.equal(['aaa']);
 
-  const lc2 = new LogContext('debug').addContext('bbb');
+  const lc2 = new LogContext('debug').withContext('bbb');
   lc2.debug?.('ccc');
   expect(mockDebug.lastCall.args).to.deep.equal(['bbb', 'ccc']);
 
-  const lc3 = lc2.addContext('ddd');
+  const lc3 = lc2.withContext('ddd');
   lc3.debug?.('eee');
   expect(mockDebug.lastCall.args).to.deep.equal(['bbb', 'ddd', 'eee']);
 
-  const lc4 = lc2.addContext('fff', 'ggg');
+  const lc4 = lc2.withContext('fff', 'ggg');
   lc4.debug?.('hhh');
   expect(mockDebug.lastCall.args).to.deep.equal(['bbb', 'fff=ggg', 'hhh']);
 });
@@ -165,11 +165,11 @@ test('Optional tag', () => {
   lc.debug?.('a');
   expect(mockDebug.lastCall.args).to.deep.equal(['a']);
 
-  const lc2 = lc.addContext('b');
+  const lc2 = lc.withContext('b');
   lc2.debug?.('c');
   expect(mockDebug.lastCall.args).to.deep.equal(['b', 'c']);
 
-  const lc3 = lc.addContext('d', 'e');
+  const lc3 = lc.withContext('d', 'e');
   lc3.debug?.('f');
   expect(mockDebug.lastCall.args).to.deep.equal(['d=e', 'f']);
 });
@@ -237,9 +237,9 @@ test('Context-aware LogSink', () => {
   const lc = new LogContext('debug', sink);
 
   lc.info?.(1, 2);
-  lc.addContext('foo', {bar: 'baz'}).debug?.(3, 4);
-  lc.addContext('boo', 'oof').info?.(5, 6);
-  lc.addContext('abc', 'is').addContext('easy', 'as').info?.(1, 2, 3);
+  lc.withContext('foo', {bar: 'baz'}).debug?.(3, 4);
+  lc.withContext('boo', 'oof').info?.(5, 6);
+  lc.withContext('abc', 'is').withContext('easy', 'as').info?.(1, 2, 3);
   lc.debug?.(7, 8);
 
   expect(sink.messages).to.deep.equal([

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -234,7 +234,7 @@ test('Context-aware LogSink', () => {
 
   expect(sink.messages).to.deep.equal([]);
 
-  const lc = new LogContext('debug', sink);
+  const lc = new LogContext('debug', undefined, sink);
 
   lc.info?.(1, 2);
   lc.withContext('foo', {bar: 'baz'}).debug?.(3, 4);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -110,9 +110,7 @@ export class FormatLogger implements LogSink {
   }
 
   log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
-    console[level](
-      ...this._format(level, ...stringified(context).concat(args)),
-    );
+    console[level](...this._format(level, ...stringified(context), ...args));
   }
 }
 
@@ -123,7 +121,8 @@ export const nodeConsoleLogSink: LogSink = {
   log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
     console[level](
       logLevelPrefix[level],
-      ...stringified(context).concat(args).map(normalizeArgument),
+      ...stringified(context),
+      ...args.map(normalizeArgument),
     );
   },
 };
@@ -157,7 +156,7 @@ export class SilentLogger implements OptionalLogger {}
 export class LogContext extends OptionalLoggerImpl {
   private readonly _logSink: LogSink;
   private readonly _level: LogLevel;
-  private readonly _context?: Context;
+  private readonly _context: Context | undefined;
 
   constructor(
     level: LogLevel = 'info',

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -161,8 +161,8 @@ export class LogContext extends OptionalLoggerImpl {
 
   constructor(
     level: LogLevel = 'info',
-    logSink: LogSink = consoleLogSink,
     context?: Context,
+    logSink: LogSink = consoleLogSink,
   ) {
     super(logSink, level, context);
     this._level = level;
@@ -176,7 +176,7 @@ export class LogContext extends OptionalLoggerImpl {
    */
   withContext(key: string, value?: unknown): LogContext {
     const ctx = {...this._context, [key]: value};
-    return new LogContext(this._level, this._logSink, ctx);
+    return new LogContext(this._level, ctx, this._logSink);
   }
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,8 +18,19 @@ export interface OptionalLogger {
  */
 export type LogLevel = 'error' | 'info' | 'debug';
 
+/**
+ * A Context ferries additional information that can be associated with
+ * each logged message. The handling of the information in the Context is
+ * specific to the LogSink; text-only implementations generally prepend
+ * stringified representations of the Context's properties to the logged
+ * message.
+ */
+export type Context = {
+  [key: string]: unknown | undefined;
+};
+
 export interface LogSink {
-  log(level: LogLevel, ...args: unknown[]): void;
+  log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void;
   flush?(): Promise<void>;
 }
 
@@ -33,9 +44,9 @@ export class TeeLogSink implements LogSink {
     this._sinks = sinks;
   }
 
-  log(level: LogLevel, ...args: unknown[]): void {
+  log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
     for (const logger of this._sinks) {
-      logger.log(level, ...args);
+      logger.log(level, context, ...args);
     }
   }
 
@@ -49,11 +60,11 @@ export class OptionalLoggerImpl implements OptionalLogger {
   readonly info?: (...args: unknown[]) => void = undefined;
   readonly error?: (...args: unknown[]) => void = undefined;
 
-  constructor(logSink: LogSink, level: LogLevel = 'info') {
+  constructor(logSink: LogSink, level: LogLevel = 'info', context?: Context) {
     const impl =
       (level: LogLevel) =>
       (...args: unknown[]) =>
-        logSink.log(level, ...args);
+        logSink.log(level, context, ...args);
 
     /* eslint-disable no-fallthrough , @typescript-eslint/ban-ts-comment */
     switch (level) {
@@ -74,8 +85,8 @@ export class OptionalLoggerImpl implements OptionalLogger {
  * Create a logger that will log to the console.
  */
 export class ConsoleLogger extends OptionalLoggerImpl {
-  constructor(level: LogLevel) {
-    super(consoleLogSink, level);
+  constructor(level: LogLevel, context?: Context) {
+    super(consoleLogSink, level, context);
   }
 }
 
@@ -83,8 +94,8 @@ export class ConsoleLogger extends OptionalLoggerImpl {
  * An implementation of [[LogSink]] that logs using `console.log` etc
  */
 export const consoleLogSink: LogSink = {
-  log(level: LogLevel, ...args: unknown[]): void {
-    console[level](...args.map(normalizeArgument));
+  log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
+    console[level](...stringified(context).concat(args).map(normalizeArgument));
   },
 };
 
@@ -98,8 +109,10 @@ export class FormatLogger implements LogSink {
     this._format = format;
   }
 
-  log(level: LogLevel, ...args: unknown[]): void {
-    console[level](...this._format(level, ...args));
+  log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
+    console[level](
+      ...this._format(level, ...stringified(context).concat(args)),
+    );
   }
 }
 
@@ -107,8 +120,11 @@ export class FormatLogger implements LogSink {
  * A console logger that prefixes log lines with a log level.
  */
 export const nodeConsoleLogSink: LogSink = {
-  log(level: LogLevel, ...args: unknown[]): void {
-    console[level](logLevelPrefix[level], ...args.map(normalizeArgument));
+  log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
+    console[level](
+      logLevelPrefix[level],
+      ...stringified(context).concat(args).map(normalizeArgument),
+    );
   },
 };
 
@@ -128,39 +144,49 @@ export const logLevelPrefix = {
 export class SilentLogger implements OptionalLogger {}
 
 /**
- * The LogContext carries a contextual tag around and it prefixes the log
- * messages with a tag.
+ * The LogContext facilitates constructing and adding to the
+ * Context passed to the LogSink.
  *
  * Typical usage is something like:
  *
  *   const lc = new LogContext('debug');
  *   lc.debug?.('hello');
  *   const lc2 = lc.addContext('foo');
- *   f(lc2);  // logging inside f will be prefixed with 'foo'
+ *   f(lc2);  // logging inside f will contain 'foo' in the Context.
  */
 export class LogContext extends OptionalLoggerImpl {
   private readonly _logSink: LogSink;
   private readonly _level: LogLevel;
+  private readonly _context?: Context;
 
-  constructor(level: LogLevel = 'info', logSink: LogSink = consoleLogSink) {
-    super(logSink, level);
+  constructor(
+    level: LogLevel = 'info',
+    logSink: LogSink = consoleLogSink,
+    context?: Context,
+  ) {
+    super(logSink, level, context);
     this._level = level;
     this._logSink = logSink;
+    this._context = context;
   }
 
   /**
-   * Creates a new Logger that will prefix all log messages with the given key
-   * and value.
+   * Creates a new Logger that with the given key and value
+   * added to the logged Context.
    */
   addContext(key: string, value?: unknown): LogContext {
-    const ctx = value === undefined ? key : `${key}=${value}`;
-    const logSink: LogSink = {
-      log: (level, ...args) => {
-        this._logSink.log(level, ctx, ...args);
-      },
-    };
-    return new LogContext(this._level, logSink);
+    const ctx = {...this._context, [key]: value};
+    return new LogContext(this._level, this._logSink, ctx);
   }
+}
+
+function stringified(context: Context | undefined): unknown[] {
+  const args = [];
+  for (const [k, v] of Object.entries(context ?? {})) {
+    const arg = v === undefined ? k : `${k}=${v}`;
+    args.push(arg);
+  }
+  return args;
 }
 
 function normalizeArgument(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -151,7 +151,7 @@ export class SilentLogger implements OptionalLogger {}
  *
  *   const lc = new LogContext('debug');
  *   lc.debug?.('hello');
- *   const lc2 = lc.addContext('foo');
+ *   const lc2 = lc.withContext('foo');
  *   f(lc2);  // logging inside f will contain 'foo' in the Context.
  */
 export class LogContext extends OptionalLoggerImpl {
@@ -174,7 +174,7 @@ export class LogContext extends OptionalLoggerImpl {
    * Creates a new Logger that with the given key and value
    * added to the logged Context.
    */
-  addContext(key: string, value?: unknown): LogContext {
+  withContext(key: string, value?: unknown): LogContext {
     const ctx = {...this._context, [key]: value};
     return new LogContext(this._level, this._logSink, ctx);
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -95,7 +95,7 @@ export class ConsoleLogger extends OptionalLoggerImpl {
  */
 export const consoleLogSink: LogSink = {
   log(level: LogLevel, context: Context | undefined, ...args: unknown[]): void {
-    console[level](...stringified(context).concat(args).map(normalizeArgument));
+    console[level](...stringified(context), ...args.map(normalizeArgument));
   },
 };
 


### PR DESCRIPTION
Logger-side changes to support https://github.com/rocicorp/mono/issues/191

Also rename `LogContext.addContext()` to `LogContext.withContext()` to better convey the immutability of the API.

Note: breaking API change