### PR TITLE
perf: avoid per-call closure allocations in OptionalLoggerImpl

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -82,6 +82,33 @@ test('level to method', () => {
   }
 });
 
+test('log methods are shared across instances (no per-call closures)', () => {
+  const sink = new TestLogSink();
+
+  // The enabled log methods should be the *same* function reference across
+  // instances built from the same class, proving they are not freshly
+  // allocated closures per construction.
+  const a = new OptionalLoggerImpl(sink, 'debug');
+  const b = new OptionalLoggerImpl(sink, 'debug');
+  expect(a.debug).toBe(b.debug);
+  expect(a.info).toBe(b.info);
+  expect(a.warn).toBe(b.warn);
+  expect(a.error).toBe(b.error);
+  expect(a.flush).toBe(b.flush);
+
+  // Even though the method reference is shared, each instance logs with its
+  // own context (the methods read instance fields via `this`).
+  const c = new OptionalLoggerImpl(sink, 'debug', {a: 1});
+  const d = new OptionalLoggerImpl(sink, 'debug', {b: 2});
+  expect(c.debug).toBe(d.debug);
+  c.debug?.('x');
+  d.debug?.('y');
+  expect(sink.messages).toEqual([
+    ['debug', {a: 1}, ['x']],
+    ['debug', {b: 2}, ['y']],
+  ]);
+});
+
 test('FormatLogger', () => {
   const mockDebug = mockConsoleMethod('debug');
   const mockInfo = mockConsoleMethod('info');

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -90,34 +90,61 @@ export class OptionalLoggerImpl<
   readonly error?: ((...args: Error) => void) | undefined = undefined;
   readonly flush: () => Promise<void>;
 
+  readonly #logSink: LogSink<Error, Warn, Info, Debug>;
+  readonly #context: Context | undefined;
+
   constructor(
     logSink: LogSink<Error, Warn, Info, Debug>,
     level: LogLevel = 'info',
     context?: Context,
   ) {
-    const impl =
-      (level: LogLevel) =>
-      (...args: unknown[]) =>
-        logSink.log(level, context, ...args);
+    this.#logSink = logSink;
+    this.#context = context;
 
+    // Assign shared private-method references (rather than freshly allocated
+    // closures) to the enabled log methods. The methods read `this.#logSink`
+    // and `this.#context`, so they behave identically while avoiding a new
+    // closure allocation per method on every construction. The methods remain
+    // `undefined` below the configured level so that `lc.debug?.(expensive())`
+    // still short-circuits and never evaluates its arguments.
     /* eslint-disable no-fallthrough , @typescript-eslint/ban-ts-comment */
     switch (level) {
       // @ts-ignore
       case 'debug':
-        this.debug = impl('debug');
+        this.debug = this.#debug;
       // @ts-ignore
       case 'info':
-        this.info = impl('info');
+        this.info = this.#info;
       // @ts-ignore
       case 'warn':
-        this.warn = impl('warn');
+        this.warn = this.#warn;
       // @ts-ignore
       case 'error':
-        this.error = impl('error');
+        this.error = this.#error;
     }
     /* eslint-enable @typescript-eslint/ban-ts-comment, no-fallthrough */
 
-    this.flush = () => logSink.flush?.() ?? Promise.resolve();
+    this.flush = this.#flush;
+  }
+
+  #debug(...args: unknown[]): void {
+    this.#logSink.log('debug', this.#context, ...args);
+  }
+
+  #info(...args: unknown[]): void {
+    this.#logSink.log('info', this.#context, ...args);
+  }
+
+  #warn(...args: unknown[]): void {
+    this.#logSink.log('warn', this.#context, ...args);
+  }
+
+  #error(...args: unknown[]): void {
+    this.#logSink.log('error', this.#context, ...args);
+  }
+
+  #flush(): Promise<void> {
+    return this.#logSink.flush?.() ?? Promise.resolve();
   }
 }
 


### PR DESCRIPTION
## Motivation

`LogContext.withContext` constructs a new `OptionalLoggerImpl` on every call, and it is called all over hot paths (per request, per IVM operation, per SQLite fetch, etc.), so its allocation cost shows up as GC pressure across the whole system.

The old `OptionalLoggerImpl` constructor allocated a **fresh closure per log method** (`debug`/`info`/`warn`/`error`) plus the `flush` closure on every construction — ~5 closure allocations per `withContext` call.

## Change

Store `logSink` and `context` as private instance fields and assign **shared private-method references** to the enabled log methods instead of freshly allocated closures. The methods read `this.#logSink` and `this.#context`, so the same function object is reused across all instances while behavior is identical.

This drops the ~5 per-instance closures, leaving only the spread context object + the instance per `withContext` (~7 → 2 allocations).

## Semantics preserved

- Methods remain `undefined` below the configured level, so `lc.debug?.(expensive())` still short-circuits and never evaluates its arguments.
- The fall-through `switch` is kept exactly as-is (each level enables itself and all higher-severity levels).
- When enabled, `lc.debug(...args)` calls `logSink.log('debug', context, ...args)` exactly as before.
- `flush()` behavior unchanged.
- No public API or type changes.

## Validation

- `pnpm build`, `pnpm lint`, and `pnpm test` all pass.
- Added a test asserting the enabled log methods are the *same function reference* across instances (proving no per-call closures), while each instance still logs with its own context.

A larger, separate follow-up (defer the context-object spread via a parent-pointer representation materialized lazily in the sink's `stringified()` path) is intentionally left out of this PR since it would change the context representation seen by all `LogSink` implementations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPBdd6YFxf3H7qjwDyALNw)_