### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,28 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/rocicorp/devcontainer-features/agents:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:172905cd57fbc946323644a52d5829415c77ff8c6f217594720966efcba11db6",
+      "integrity": "sha256:172905cd57fbc946323644a52d5829415c77ff8c6f217594720966efcba11db6",
+      "dependsOn": [
+        "ghcr.io/anthropics/devcontainer-features/claude-code:1",
+        "ghcr.io/devcontainers/features/github-cli:1"
+      ]
+    },
+    "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/rocicorp/devcontainer-features/pnpm@sha256:9ec391d0106040bf61d2ea2f7194cc935cf25fa43b4d542aee3514e23d437e0d",
+      "integrity": "sha256:9ec391d0106040bf61d2ea2f7194cc935cf25fa43b4d542aee3514e23d437e0d"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// Rocicorp dev container for the logger library.
+//
+// Unlike hello-zero, logger is a standalone library with no database or other
+// sibling services, so this is a plain single-image dev container — no Compose.
+//
+// Security invariant: the dev container is the sandbox for development and
+// AI-agent work. It must not be able to create or control containers — no
+// Docker-in-Docker, no host Docker socket.
+// See https://github.com/rocicorp/devcontainer-templates
+{
+  "name": "logger",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+  "workspaceFolder": "/workspaces/logger",
+  "remoteUser": "node",
+  // Forward the host's GITHUB_TOKEN into the container. Under agents:2, gh
+  // authenticates from this token rather than a persisted login. On the host,
+  // export GITHUB_TOKEN (e.g. from 1Password) before launching VS Code. See
+  // https://github.com/rocicorp/devcontainer-features#gh-auth-via-1password-no-host-side-credentials
+  "remoteEnv": {
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
+  },
+  "features": {
+    // Shared rocicorp features (https://github.com/rocicorp/devcontainer-features):
+    //  - agents: Codex (pinned) + Claude Code + gh; persists the Claude login
+    //    across rebuilds; gh uses the forwarded GITHUB_TOKEN.
+    //  - pnpm: corepack-managed pnpm; removes npm/npx to enforce pnpm.
+    "ghcr.io/rocicorp/devcontainer-features/agents:2": {},
+    "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {}
+  },
+  "postCreateCommand": "pnpm install"
+}


### PR DESCRIPTION
Adds a dev container for the logger repo, modeled on the one in hello-zero.

Since logger is a standalone library with no database or other sibling services, this drops the Docker Compose orchestration that hello-zero needs and uses a plain single-image dev container instead.

## What's included
- `mcr.microsoft.com/devcontainers/javascript-node:24` base image
- Shared rocicorp dev container features:
  - `agents:2` — Codex + Claude Code + gh, persists the Claude login across rebuilds
  - `pnpm:1` — corepack-managed pnpm, removes npm/npx to enforce pnpm
- `GITHUB_TOKEN` forwarded from the host for `gh` auth
- `postCreateCommand: pnpm install`
- Pinned feature versions in `devcontainer-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)