### PR TITLE
ci: add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # required for npm OIDC trusted publishing
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -20,15 +20,13 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
-          registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-
+      # corepack activates pnpm@11.1.3 from package.json's packageManager field.
+      # pnpm >=11.0.7 supports npm OIDC trusted publishing natively (and 11.1.3
+      # fixes the setup-node .npmrc interaction, pnpm#11513), so no NPM_TOKEN
+      # secret and no npm upgrade are needed.
       - name: Enable Corepack
         run: corepack enable
-
-      - name: Upgrade npm for OIDC trusted publishing support
-        run: COREPACK_ENABLE_STRICT=0 npm install --global npm@latest
 
       - name: Print tool versions
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,11 +36,6 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Print tool versions
-        run: |
-          pnpm --version
-          npm --version
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,17 @@ on:
       - 'v*'
   # pull_request:
 
+# Default-deny: grant tokens only to the jobs/steps that need them.
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Gate publishes behind the "release" environment. Configure protection
+    # rules on it in repo Settings → Environments (required reviewers, and a
+    # deployment branch/tag policy limited to v* tags) so a publish can only
+    # run from a release tag and, optionally, after manual approval.
+    environment: release
     permissions:
       contents: read
       id-token: write # required for npm OIDC trusted publishing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # pull_request:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24.x'
+          registry-url: https://registry.npmjs.org
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Upgrade npm for OIDC trusted publishing support
+        run: COREPACK_ENABLE_STRICT=0 npm install --global npm@latest
+
+      - name: Print tool versions
+        run: |
+          pnpm --version
+          npm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm run build
+
+      - name: Publish to npm with trusted publishing
+        run: pnpm publish --access public --provenance --no-git-checks ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}


### PR DESCRIPTION
Adds an npm publish workflow using GitHub Actions OIDC **trusted publishing**, modeled on [rocicorp/zero-virtual](https://github.com/rocicorp/zero-virtual)'s `publish.yml`.

## How it works
- Triggers on `v*` tag pushes.
- Runs in a **`release`** GitHub environment so the publish can be gated with required reviewers and a deployment policy limited to `v*` tags.
- Top-level `permissions: {}` (default-deny); the publish job is granted only `contents: read` + `id-token: write`.
- `corepack enable` activates the pinned `pnpm@11.1.3`, which supports npm OIDC trusted publishing natively (pnpm ≥11.0.7; 11.1.3 includes the `setup-node` `.npmrc` fix, pnpm#11513) — **no `NPM_TOKEN` secret and no npm upgrade needed**.
- Builds via `pnpm run build`, then `pnpm publish --access public --provenance`.

## One-time setup required
1. **npm trusted publisher** — on npmjs.com → `@rocicorp/logger` package settings → **Trusted Publisher**, add this repo + the `Publish` workflow (`.github/workflows/publish.yml`). Until configured, the publish step fails auth.
2. **`release` environment** — in repo Settings → Environments, create `release` and (recommended) add required reviewers and a deployment branch/tag rule limited to `v*`.

Adapted from the template: Node 24.x (matching the dev container) and logger's `pnpm run build` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)