### PR TITLE
ci(merge-queue): run required checks on merge_group

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,6 +4,7 @@
 name: Test
 
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
Adds a `merge_group:` trigger to the workflows that produce required status checks, so they report against the merge queue's merge-group ref instead of stalling at "waiting for status".