### PR TITLE
fix: fixed conditional logger methods

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -82,31 +82,31 @@ test('level to method', () => {
   }
 });
 
-test('log methods are shared across instances (no per-call closures)', () => {
-  const sink = new TestLogSink();
+test('log methods can be extracted from instances', async () => {
+  const sink = new TestLogSinkWithFlush();
 
-  // The enabled log methods should be the *same* function reference across
-  // instances built from the same class, proving they are not freshly
-  // allocated closures per construction.
-  const a = new OptionalLoggerImpl(sink, 'debug');
-  const b = new OptionalLoggerImpl(sink, 'debug');
-  expect(a.debug).toBe(b.debug);
-  expect(a.info).toBe(b.info);
-  expect(a.warn).toBe(b.warn);
-  expect(a.error).toBe(b.error);
-  expect(a.flush).toBe(b.flush);
+  const a = new OptionalLoggerImpl(sink, 'debug', {a: 1});
+  const b = new OptionalLoggerImpl(sink, 'debug', {b: 2});
 
-  // Even though the method reference is shared, each instance logs with its
-  // own context (the methods read instance fields via `this`).
-  const c = new OptionalLoggerImpl(sink, 'debug', {a: 1});
-  const d = new OptionalLoggerImpl(sink, 'debug', {b: 2});
-  expect(c.debug).toBe(d.debug);
-  c.debug?.('x');
-  d.debug?.('y');
+  const {debug, info, warn, error, flush} = a;
+
+  debug?.('debug');
+  info?.('info');
+  warn?.('warn');
+  error?.('error');
+  await flush();
+
+  const selectedLog = sink.messages.length > 0 ? b.info : b.debug;
+  selectedLog?.('selected');
+
   expect(sink.messages).toEqual([
-    ['debug', {a: 1}, ['x']],
-    ['debug', {b: 2}, ['y']],
+    ['debug', {a: 1}, ['debug']],
+    ['info', {a: 1}, ['info']],
+    ['warn', {a: 1}, ['warn']],
+    ['error', {a: 1}, ['error']],
+    ['info', {b: 2}, ['selected']],
   ]);
+  expect(sink.flushCount).toBe(1);
 });
 
 test('FormatLogger', () => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -88,61 +88,37 @@ export class OptionalLoggerImpl<
   readonly error?: ((...args: Error) => void) | undefined = undefined;
   readonly flush: () => Promise<void>;
 
-  readonly #logSink: LogSink<Error, Warn, Info, Debug>;
-  readonly #context: Context | undefined;
-
   constructor(
     logSink: LogSink<Error, Warn, Info, Debug>,
     level: LogLevel = 'info',
     context?: Context,
   ) {
-    this.#logSink = logSink;
-    this.#context = context;
+    const debug = (...args: Debug) => logSink.log('debug', context, ...args);
+    const info = (...args: Info) => logSink.log('info', context, ...args);
+    const warn = (...args: Warn) => logSink.log('warn', context, ...args);
+    const error = (...args: Error) => logSink.log('error', context, ...args);
 
-    // Assign shared private-method references (rather than freshly allocated
-    // closures) to the enabled log methods. The methods read `this.#logSink`
-    // and `this.#context`, so they behave identically while avoiding a new
-    // closure allocation per method on every construction. The methods remain
-    // `undefined` below the configured level so that `lc.debug?.(expensive())`
-    // still short-circuits and never evaluates its arguments.
+    // The enabled methods remain `undefined` below the configured level so that
+    // `lc.debug?.(expensive())` still short-circuits and never evaluates its
+    // arguments. They are plain functions so callers can safely extract them.
     /* eslint-disable no-fallthrough , @typescript-eslint/ban-ts-comment */
     switch (level) {
       // @ts-ignore
       case 'debug':
-        this.debug = this.#debug;
+        this.debug = debug;
       // @ts-ignore
       case 'info':
-        this.info = this.#info;
+        this.info = info;
       // @ts-ignore
       case 'warn':
-        this.warn = this.#warn;
+        this.warn = warn;
       // @ts-ignore
       case 'error':
-        this.error = this.#error;
+        this.error = error;
     }
     /* eslint-enable @typescript-eslint/ban-ts-comment, no-fallthrough */
 
-    this.flush = this.#flush;
-  }
-
-  #debug(...args: unknown[]): void {
-    this.#logSink.log('debug', this.#context, ...args);
-  }
-
-  #info(...args: unknown[]): void {
-    this.#logSink.log('info', this.#context, ...args);
-  }
-
-  #warn(...args: unknown[]): void {
-    this.#logSink.log('warn', this.#context, ...args);
-  }
-
-  #error(...args: unknown[]): void {
-    this.#logSink.log('error', this.#context, ...args);
-  }
-
-  #flush(): Promise<void> {
-    return this.#logSink.flush?.() ?? Promise.resolve();
+    this.flush = () => logSink.flush?.() ?? Promise.resolve();
   }
 }
 


### PR DESCRIPTION
Make `OptionalLoggerImpl` log methods safe to call after extraction or conditional selection.

Fixes the behavioral regression introduced in https://github.com/rocicorp/logger/pull/31.

**Why this surfaced on Pro stacks (likely explanation)**

- The downstream Zero failure was in change-streamer catchup logging. Zero conditionally selected a logger method with code equivalent to `(elapsed > 100 ? lc.info : lc.debug)?.(...)`.
- With the default `info` log level, `lc.debug` is `undefined`, so fast waits skip logging and do not trigger the bug. Only waits over 100 ms select `lc.info`, and logger 6.0.0 then throws if that selected method is called without its receiver.
- The error included `backup-replicator-*`, meaning it happened while the replication-manager backup replica was catching up from the change DB. Pro stacks are larger/hotter and default to more serving capacity, so backup catchup is more likely to have enough backlog or downstream write latency for a batch wait to exceed 100 ms.
- Hobby stacks on the same Zero version are still vulnerable; they likely avoided the incident because their backup catchup waits did not cross the slow-log threshold during the observed window.
