### PR TITLE
fix: improve type checking for OptionalLoggerImpl

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "vitest run src/",
     "test:watch": "vitest src/",
+    "fmt": "oxfmt src/",
     "format": "oxfmt src/",
     "check-format": "oxfmt --check src/",
     "lint": "eslint src/",

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -412,14 +412,17 @@ function testNormalizeError(stringifiedError: string) {
   });
 }
 
-test.skip('type checking', () => {
+test('type checking', () => {
   expect(true).toBe(true);
 
   const lc = new OptionalLoggerImpl(consoleLogSink, 'debug', {foo: 'bar'});
   const {debug} = lc;
 
-  // @ts-expect-error Should not allow extracted method.
-  debug?.('a');
+  const f = () => {
+    // @ts-expect-error Should not allow extracted method.
+    debug?.('a');
+  };
+  expect(f).toThrowError()
 
   // OK
   debug?.call(lc, 'a');

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -422,7 +422,7 @@ test('type checking', () => {
     // @ts-expect-error Should not allow extracted method.
     debug?.('a');
   };
-  expect(f).toThrowError()
+  expect(f).toThrowError();
 
   // OK
   debug?.call(lc, 'a');

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,19 +11,11 @@ export interface OptionalLogger<
   Info extends unknown[] = unknown[],
   Debug extends unknown[] = unknown[],
 > {
-  error?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Error) => void)
-    | undefined;
-  info?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Info) => void)
-    | undefined;
-  warn?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Warn) => void)
-    | undefined;
-  debug?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Debug) => void)
-    | undefined;
-  flush?(this: OptionalLogger<Error, Warn, Info, Debug>): Promise<void>;
+  error?: ((this: this, ...args: Error) => void) | undefined;
+  info?: ((this: this, ...args: Info) => void) | undefined;
+  warn?: ((this: this, ...args: Warn) => void) | undefined;
+  debug?: ((this: this, ...args: Debug) => void) | undefined;
+  flush?(this: this): Promise<void>;
 }
 
 /**
@@ -90,21 +82,13 @@ export class OptionalLoggerImpl<
   Info extends unknown[] = unknown[],
   Debug extends unknown[] = unknown[],
 > implements OptionalLogger<Error, Warn, Info, Debug> {
-  readonly debug?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Debug) => void)
-    | undefined = undefined;
-  readonly info?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Info) => void)
-    | undefined = undefined;
-  readonly warn?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Warn) => void)
-    | undefined = undefined;
-  readonly error?:
-    | ((this: OptionalLogger<Error, Warn, Info, Debug>, ...args: Error) => void)
-    | undefined = undefined;
-  readonly flush: (
-    this: OptionalLogger<Error, Warn, Info, Debug>,
-  ) => Promise<void>;
+  readonly debug?: ((this: this, ...args: Debug) => void) | undefined =
+    undefined;
+  readonly info?: ((this: this, ...args: Info) => void) | undefined = undefined;
+  readonly warn?: ((this: this, ...args: Warn) => void) | undefined = undefined;
+  readonly error?: ((this: this, ...args: Error) => void) | undefined =
+    undefined;
+  readonly flush: (this: this) => Promise<void>;
 
   readonly #logSink: LogSink<Error, Warn, Info, Debug>;
   readonly #context: Context | undefined;


### PR DESCRIPTION
Use the `this` type and not the interface because the implementation has private fields.